### PR TITLE
Mc hit different endpoints in prod

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,8 @@ import injectSheet from 'react-jss'
 import Home from './components/Home'
 import Login from './components/Login'
 
+import { API_ROOT } from './api-config'
+
 const styles = {
   errors: {
     color: '#00C457',
@@ -19,8 +21,7 @@ class App extends Component {
   constructor (props) {
     super(props)
 
-    this.url = 'https://spotify-viz-api.herokuapp.com'
-    // this.url = 'http://localhost:3001'
+    this.url = API_ROOT
 
     this.state = {
       loggedIn: false,

--- a/src/api-config.js
+++ b/src/api-config.js
@@ -1,0 +1,10 @@
+let backendHost
+const hostname = window && window.location && window.location.hostname
+
+if (hostname === 'ear-worm.com' || hostname === 'spotify-viz-frontend.herokuapp.com') {
+  backendHost = 'https://spotify-viz-api.herokuapp.com'
+} else {
+  backendHost = 'http://localhost:3001'
+}
+
+export const API_ROOT = backendHost

--- a/src/lib/apiService.js
+++ b/src/lib/apiService.js
@@ -1,7 +1,8 @@
 import axios from 'axios'
 
-let uri = 'https://spotify-viz-api.herokuapp.com'
-// let uri = 'http://localhost:3001'
+import { API_ROOT } from '../api-config'
+
+let uri = API_ROOT
 let url = `${uri}/search?`
 
 export const getSong = value => {


### PR DESCRIPTION
## Purpose

Fixes #27 

Before making this adjustment, I needed to update the api root I was hitting whenever I wanted to add a feature. Then, I had to remember to replace it with the production endpoint when I was deploying. I frequently forgot to do so. This way, the application dynamically knows whether I am in development or production.

## Approach
I chose to create an `api-config.js` file, in which I check what url I am at. If I'm on localhost, I hit the API at `https://localhost:3001`. Otherwise, I hit the production endpoint.

#### Open Questions and Pre-Merge TODOs
N/A

## Learning
[Using React in Multiple Environments](https://daveceddia.com/multiple-environments-with-react/)